### PR TITLE
Ux issues

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -49,12 +49,12 @@ defaults:
       standalone_resource_nav_links:
         - name: Home
           ref: /
-        - name: Patterns and Widgets
-          ref: /patterns/
-        - name: Examples
-          ref: /examples/
         - name: Fundamentals
           ref: /fundamentals/
+        - name: Patterns and Widgets
+          ref: /patterns/
+        - name: Indexes
+          ref: /examples/
         - name: About
           ref: /about/
 #  -

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -31,6 +31,17 @@ a.skip-main:focus, a.skip-main:active {
   font-size: 1.2em;
   z-index: 999;
 }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}
           
 /* Design Patterns and Widgets and Fundamentals */
 ul.tiles {
@@ -63,16 +74,16 @@ li.tile {
   border-radius: 4px;
 }
 
-li.tile a {
+li.tile .tile-name a {
   text-decoration: none;
   color: var(--wai-green);
 }
 
-li.tile a:hover {
+li.tile .tile-name a:hover {
   text-decoration: underline;
 }
 
-li.tile a:focus {
+li.tile .tile-name a:focus {
   display: flex;
   align-items: flex-start;
   outline-offset: 8px;
@@ -100,6 +111,18 @@ li.tile .tile-introduction {
   padding-top: 1em;
   margin-top: 1.25em;
 }
+
+li.tile .tile-introduction p {
+  margin: 0;
+}
+
+/* li.tile .tile-introduction a {
+  text-decoration: underline;
+}
+
+li.tile .tile-introduction a:hover {
+  color: #036;
+} */
 
 /* Sidebar Content */
 .sidebar-container {

--- a/scripts/pre-build/library/organizeForJekyll/pages/getFundamentalsPage.js
+++ b/scripts/pre-build/library/organizeForJekyll/pages/getFundamentalsPage.js
@@ -16,7 +16,9 @@ const getFundamentalsPage = (fundamentals) => {
                     <span>${fundamental.name}</span>
                   </a>
                 </h2>
-                <div class="tile-introduction">${fundamental.introduction}</div>
+                <div class="tile-introduction">
+                  <p>${fundamental.introduction} <a href="${fundamental.slug}">Read more<span class="sr-only"> about ${fundamental.name}</span></a></p>
+                </div>
               </li>
             `;
           })

--- a/scripts/pre-build/library/organizeForJekyll/pages/getPatternsPage.js
+++ b/scripts/pre-build/library/organizeForJekyll/pages/getPatternsPage.js
@@ -17,7 +17,9 @@ const getPatternsPage = (patterns) => {
                     <span>${pattern.name}</span>
                   </a>
                 </h2>
-                <div class="tile-introduction">${pattern.introduction}</div>
+                <div class="tile-introduction">
+                  <p>${pattern.introduction} <a href="${pattern.permalink}">Read more<span class="sr-only"> about ${pattern.slug}</span></a></p>
+                </div>
               </li>
             `;
           })


### PR DESCRIPTION
-  In the main Nav, change the word “Examples” to “Index”
   - Note: this is partially fixed. The URL needs to be updated
-  Reprioritize Navigation items by moving Fundamentals to be next to Home.
-  Add “Read more about x” link to cards under Patterns and Fundamentals pages