### PR TITLE
Update `.gitmodules` to include wai-website-data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "_external/aria-practices"]
 	path = _external/aria-practices
 	url = git@github.com:w3c/aria-practices.git
+[submodule "_external/data"]
+	path = _external/data
+	url = https://github.com/w3c/wai-website-data.git


### PR DESCRIPTION
It seems there is a missing dependency in the `.gitmodules` file which hinders the expected result of the `Initialize submodules` step in the README.

Without this change, unexpected behaviors will happen when running `bundle exec jekyll serve`